### PR TITLE
Changed cast that warned about conversions in arm to char

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-utf-range"
-        VERSION "2.2.2"
+        VERSION "2.2.3"
         DESCRIPTION "UTF8 Iterator/Range for traversing utf8 text"
         HOMEPAGE_URL "https://github.com/beached/utf_range"
         LANGUAGES C CXX

--- a/include/daw/utf8/unchecked.h
+++ b/include/daw/utf8/unchecked.h
@@ -27,26 +27,31 @@ DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #include "core.h"
+
 #include <daw/cpp_17.h>
+#include <daw/daw_traits.h>
+
+#include <iterator>
 
 namespace daw::utf8::unchecked {
 	template<typename octet_iterator>
 	constexpr octet_iterator append( uint32_t cp,
 	                                 octet_iterator result ) noexcept {
+
 		if( cp < 0x80 ) { // one octet
-			*( result++ ) = static_cast<int8_t>( cp );
+			*( result++ ) = static_cast<char>( cp );
 		} else if( cp < 0x800 ) { // two octets
-			*( result++ ) = static_cast<int8_t>( ( cp >> 6 ) | 0xc0 );
-			*( result++ ) = static_cast<int8_t>( ( cp & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( cp >> 6 ) | 0xc0 );
+			*( result++ ) = static_cast<char>( ( cp & 0x3f ) | 0x80 );
 		} else if( cp < 0x10000 ) { // three octets
-			*( result++ ) = static_cast<int8_t>( ( cp >> 12 ) | 0xe0 );
-			*( result++ ) = static_cast<int8_t>( ( ( cp >> 6 ) & 0x3f ) | 0x80 );
-			*( result++ ) = static_cast<int8_t>( ( cp & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( cp >> 12 ) | 0xe0 );
+			*( result++ ) = static_cast<char>( ( ( cp >> 6 ) & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( cp & 0x3f ) | 0x80 );
 		} else { // four octets
-			*( result++ ) = static_cast<int8_t>( ( cp >> 18 ) | 0xf0 );
-			*( result++ ) = static_cast<int8_t>( ( ( cp >> 12 ) & 0x3f ) | 0x80 );
-			*( result++ ) = static_cast<int8_t>( ( ( cp >> 6 ) & 0x3f ) | 0x80 );
-			*( result++ ) = static_cast<int8_t>( ( cp & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( cp >> 18 ) | 0xf0 );
+			*( result++ ) = static_cast<char>( ( ( cp >> 12 ) & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( ( cp >> 6 ) & 0x3f ) | 0x80 );
+			*( result++ ) = static_cast<char>( ( cp & 0x3f ) | 0x80 );
 		}
 		return result;
 	}


### PR DESCRIPTION
Changed cast that warned about conversions in arm to char.  It was int8_t but commonly the conversion is to char and that isn't always signed